### PR TITLE
Add EventEmitter to implementation objects if not already present.

### DIFF
--- a/examples/event/event-tessel.js
+++ b/examples/event/event-tessel.js
@@ -4,19 +4,9 @@
 */
 var tessel = require('tessel');
 var organiq = require('organiq-tessel');
-var EventEmitter = require('events').EventEmitter;  // std. node emitter
 
-// Define our device object, which simply declares the available events that
-// it raises.
-var device = {
-  // define the (custom) events that we raise.
-  events: ['buttonPress', 'buttonRelease'],
-
-  // EventEmitter support for the object
-  _emitter: new EventEmitter(),
-  on: function(ev, fn) { return this._emitter.on(ev, fn); },
-  emit: function(ev, args) { return this._emitter.emit(ev, args); }
-};
+var device = { /* device exposes no properties/methods */ };
+organiq.registerDevice('EventDevice', device);
 
 // Register for local button press/release events, and raise them on our
 // device object when they happen. This will allow them to be subscribed by
@@ -28,5 +18,4 @@ tessel.button.on('release', function() {
   device.emit('buttonRelease');
 });
 
-organiq.registerDevice('EventDevice', device);
 

--- a/lib/device.js
+++ b/lib/device.js
@@ -34,18 +34,21 @@ module.exports = DeviceWrapper;
  *
  *
  * @param {Object} impl User-supplied implementation object.
- * @param {Object=} schema schema for the device, specifying properties,
+ * @param {Object} [schema] schema for the device, specifying properties,
  *  methods, and events to expose. If omitted, the schema is created
  *  automatically by inspecting the given implementation object.
+ * @param {Object} [options] optional options
  * @constructor
  */
-function DeviceWrapper(impl, schema) {
+function DeviceWrapper(impl, schema, options) {
   if (!(this instanceof DeviceWrapper)) {
     return new DeviceWrapper(impl, schema);
   }
   this.impl = impl;
   this.schema = schema || Schema.fromObjectDefinition(impl);
   this.config = {};
+  options = options || {};
+  this.strictSchema = options.strictSchema || false;
 
   // Make sure implementation object implements all of the functions given in
   // the schema.
@@ -110,25 +113,28 @@ function DeviceWrapper(impl, schema) {
     }
   }
 
-  /**
-   *
-   * @param {DeviceWrapper} target
-   * @param {String} event
-   * @return {Function}
-   */
-  function makeEventHandler(target, event) {
-    return function() {
-      var args = [].slice.call(arguments);  // convert arguments to Array
-      target.notify(event, args);
-    };
+  // If the implementation device is not already an EventEmitter, give it an
+  // implementation.
+  var self = this;
+  if (typeof impl.on !== 'function') {
+    impl.__emitter = new EventEmitter();
+    impl.on = function(ev, fn) { return impl.__emitter.on(ev, fn); };
+    impl.emit = function() { return impl.__emitter.emit.apply(impl, arguments); };
   }
-  for (var event in this.schema.events) {
-    if (this.schema.events.hasOwnProperty(event)) {
-      if (typeof impl.on === 'function') {
-        impl.on(event, makeEventHandler(this, event));
-      }
+
+  // install emit() spy that invokes our notify()
+  impl.__emit = impl.emit;
+  impl.emit = function() {
+    var args = [].slice.call(arguments);  // convert arguments to Array
+    var event = args.shift();
+
+    // If this event is in the device schema, or we have strictSchema mode
+    // disabled, then send the event via notify().
+    if (!self.strictSchema || event in [self.schema.events]) {
+      self.notify(event, args);
     }
-  }
+    return impl.__emit.apply(impl, arguments);
+  };
 }
 util.inherits(DeviceWrapper, EventEmitter);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,7 @@ var DEFAULT_OPTIONS_PATH = './organiq.json';
  * @param {String=} options.apiToken The authentication token to use with the gateway.
  * @param {String=} options.optionsPath Defaults to './organiq.json'
  * @param {Boolean=} options.autoConnect Defaults to true.
+ * @param {Boolean=} options.strictSchema Defaults to false.
  *
  * @constructor
  */
@@ -58,6 +59,7 @@ function OrganiqContainer(options) {
   var apiToken = options.apiToken;
   var optionsPath = options.optionsPath || DEFAULT_OPTIONS_PATH;
   var autoConnect = options.autoConnect !== false;  // true if not given false
+  var strictSchema = options.strictSchema || false; // false if not given true
 
   var deferredConnection = when.defer();
   var connection$ = deferredConnection.promise;
@@ -118,12 +120,22 @@ function OrganiqContainer(options) {
   /**
    * Register a local device object with the system.
    *
+   * If `strictSchema` is enabled in options, a schema object must be provided
+   * that specifies the properties, methods, and events exposed by the device
+   * being registered. If `strictSchema` is not enabled, then the schema object
+   * is optional. If omitted in this case, a schema will be automatically
+   * created by inspecting the given `impl` object.
+   *
    * @param {String} deviceid
    * @param {Object} impl Native implementation object
+   * @param {Object} [schema] optional schema for interface
    * @returns {DeviceWrapper|*}
    */
-  this.registerDevice = function(deviceid, impl) {
-    var device = new Device(impl);
+  this.registerDevice = function(deviceid, impl, schema) {
+    if (strictSchema && !schema) {
+      throw new Error('Schema is required when `strictSchema` enabled');
+    }
+    var device = new Device(impl, schema, { strictSchema: strictSchema });
     return core.register(deviceid, device);
   };
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jshint": "^2.6.3",
     "minimist": "^1.1.0",
     "mocha": "^2.2.0",
+    "rewire": "^2.3.1",
     "should": "^5.1.0",
     "sinon": "^1.13.0",
     "sinon-chai": "^2.7.0"


### PR DESCRIPTION
Also add (undocumented) strictSchema option to restrict raised events to those explicitly specified in device schema.

This allows for a much more concise way to emit objects from devices:

```javascript
var organiq = require('organiq');
var device = { /* nothing */ };
organiq.registerDevice('MyDevice', device); // emit() method automatically generated
device.emit('alert');  // alerts any (remote) listeners
```

Prior to this change, the device object would've had to implement on() and emit() itself.
