### PR TITLE
Support for namespaces

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,7 +17,8 @@ var optionsPath = './organiq.json';
 var _packageData = null;
 function writePackageData(apiRoot) {
   var packageData = {
-    'apiRoot': apiRoot
+    'apiRoot': apiRoot,
+    'namespace': defaultNamespace
   };
   var s = JSON.stringify(packageData, null, 4);
   fs.writeFileSync(optionsPath, s);
@@ -40,6 +41,7 @@ function getApiRoot() {
 }
 
 var apiRoot = getApiRoot();
+var defaultNamespace = '.';
 
 function _getLocalExternalIPAddress() {
     var os = require('os');

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ module.exports.Schema = Schema;
 
 var DEFAULT_APIROOT = 'ws://api.organiq.io';
 var DEFAULT_APITOKEN = '';
+var DEFAULT_NAMESPACE = '.';
 var DEFAULT_OPTIONS_PATH = './organiq.json';
 
 
@@ -43,6 +44,8 @@ var DEFAULT_OPTIONS_PATH = './organiq.json';
  * @param {String=} options.apiRoot The URI of the gateway server endpoint to which we
  *  should connect.
  * @param {String=} options.apiToken The authentication token to use with the gateway.
+ * @param {String=} options.namespace The namespace to use for deviceids
+ *  when one is not specified. Defaults to the global namespace ('.').
  * @param {String=} options.optionsPath Defaults to './organiq.json'
  * @param {Boolean=} options.autoConnect Defaults to true.
  * @param {Boolean=} options.strictSchema Defaults to false.
@@ -57,6 +60,7 @@ function OrganiqContainer(options) {
   options = options || {};
   var apiRoot = options.apiRoot;
   var apiToken = options.apiToken;
+  var namespace = options.namespace;
   var optionsPath = options.optionsPath || DEFAULT_OPTIONS_PATH;
   var autoConnect = options.autoConnect !== false;  // true if not given false
   var strictSchema = options.strictSchema || false; // false if not given true
@@ -74,15 +78,16 @@ function OrganiqContainer(options) {
       var config = JSON.parse(s);
       apiToken = config['token'];
       apiRoot = config['apiRoot'];
+      namespace = config['namespace'];
     }
   }
 
   apiRoot = apiRoot || process.env['ORGANIQ_APIROOT'] || DEFAULT_APIROOT;
   apiToken = apiToken || process.env['ORGANIQ_APITOKEN'] || DEFAULT_APITOKEN;
-
+  namespace = namespace || process.env['ORGANIQ_NAMESPACE'] || DEFAULT_NAMESPACE;
 
   // Create the local node.
-  var core = new organiq();
+  var core = new organiq({ defaultDomain: namespace });
 
   if (autoConnect) {
     connect(apiRoot, apiToken);
@@ -129,14 +134,17 @@ function OrganiqContainer(options) {
    * @param {String} deviceid
    * @param {Object} impl Native implementation object
    * @param {Object} [schema] optional schema for interface
-   * @returns {DeviceWrapper|*}
+   * @returns {Device}
    */
   this.registerDevice = function(deviceid, impl, schema) {
     if (strictSchema && !schema) {
       throw new Error('Schema is required when `strictSchema` enabled');
     }
     var device = new Device(impl, schema, { strictSchema: strictSchema });
-    return core.register(deviceid, device);
+    return core.register(deviceid, device).then(function(deviceid) {
+      void(deviceid); // unused
+      return device;
+    });
   };
 
 
@@ -166,7 +174,8 @@ function OrganiqContainer(options) {
       debug('getDevice received device schema.');
       return new Proxy_(schema, proxy);
     }).catch(function(err) {
-      console.log('getDevice error: '+err);
+      console.log('getDevice error: ', err);
+      throw err;
     });
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "organiq",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Organiq SDK for JavaScript.",
   "main": "./lib/index.js",
   "bin": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/organiq/organiq-sdk-js",
   "dependencies": {
-    "organiq-core": "organiq/organiq-core.git#v0.2.0",
+    "organiq-core": "organiq/organiq-core.git#v0.2.1",
     "debug": "^2.1.2",
     "when": "^3.7.2",
     "ws": "^0.7.1"


### PR DESCRIPTION
This updates the SDK to work with the new namespace functionality provided
in organiq-core v0.2.1. A new 'namespace' property can be used in organiq.json
or through other configuration mechanisms.
