### PR TITLE
Provide Browserify support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -229,6 +229,25 @@ function Organiq(options) {
   };
 
   /**
+   * Get a reference to a remote device.
+   *
+   * @param {String} deviceid
+   * @param {Object} options
+   * @return {Promise<RemoteDeviceProxy>} Promise for a proxy object
+   */
+
+  this.getDeviceById = function(deviceid, options) {
+    options = options || {};
+    var useWrapper = !!options.proxyWrapper;
+
+    if (useWrapper) {
+      throw Error('not yet supported');
+    }
+
+    return client.connect(deviceid);
+  };
+
+  /**
    * Register a device driver.
    *
    * @param {String} alias
@@ -292,6 +311,16 @@ Organiq.registerDevice = function() {
 Organiq.getDevice = function() {
   var s = Singleton.get();
   return s.getDevice.apply(s, arguments);
+};
+
+/**
+ * Calls `getDeviceById` of singleton object.
+ *
+ * @return {Promise<RemoteDeviceProxy>}
+ */
+Organiq.getDeviceById = function() {
+  var s = Singleton.get();
+  return s.getDeviceById.apply(s, arguments);
 };
 
 /**

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -14,16 +14,26 @@ module.exports = process.browser ? BrowserWebSocketShim
  * Wrapper for native browser WebSocket, making it behave like the WebSockets/ws
  * module (enough for our needs, anyhow).
  *
- * @param url
+ * @param {String} url
+ * @param {String[]=} protocols
+ * @param {Object=} options
+ * @param {Object=} options.headers Optional headers to include in request.
+ * @param {Object=} options.headers.Authorization An authorization header.
  * @return {BrowserWebSocketShim}
  * @constructor
  */
-function BrowserWebSocketShim(url) {
+function BrowserWebSocketShim(url, protocols, options) {
   if (!(this instanceof BrowserWebSocketShim)) {
-    return new BrowserWebSocketShim(url);
+    return new BrowserWebSocketShim(url, protocols, options);
   }
   var self = this;
   /*global WebSocket*/
+  // The browser WebSocket implementation does not allow for headers to be
+  // added to the upgrade request, so we're forced to put the Authorization
+  // information on the query string.
+  if (options && options.headers && options.headers['Authorization']) {
+    url += '/?Authorization=' + options.headers['Authorization'];
+  }
   var ws = new WebSocket(url);
   ws.onopen = function connect() {
     self.emit('open', self);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/organiq/organiq-sdk-js",
   "dependencies": {
     "debug": "^2.2.0",
-    "restler": "^3.3.0",
+    "restler": "^3.4.0",
     "when": "^3.7.3",
     "ws": "^0.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "jshint ./lib && mocha",
     "lint": "jshint ./lib",
+    "browserify": "browserify -x ws ./lib -o organiq.js",
     "t": "mocha"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jshint ./lib && mocha",
     "lint": "jshint ./lib",
-    "browserify": "browserify -x ws ./lib -o organiq.js",
+    "browserify": "browserify -x ws -r ./lib/index.js:organiq -o organiq.js",
     "t": "mocha"
   },
   "repository": {


### PR DESCRIPTION
In order to support use in browser environments, it was necessary to update the version of restler used, and to pass Authorization information in the websocket URI, as browser WebSocket implementations do not support passing custom headers.